### PR TITLE
Catch up with woothee v1.8.0

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -32,6 +32,23 @@ var challengeMSIE = exports.challengeMSIE = function(ua, result) {
   return true;
 };
 
+var yandexBrowserPattern = /YaBrowser\/([.0-9]+)/;
+var challengeYandexBrowser = exports.challengeYandexBrowser = function(ua, result) {
+  if (ua.indexOf('YaBrowser/') < 0)
+    return false;
+
+  var version;
+  var match = yandexBrowserPattern.exec(ua);
+  if (match) {
+    version = match[1];
+  } else {
+    version = dataset.VALUE_UNKNOWN;
+  }
+  updateMap(result, dataset.get('YaBrowser'));
+  updateVersion(result, version);
+  return true;
+};
+
 var edgePattern = /Edge\/([.0-9]+)/;
 var firefoxiOSPattern = /FxiOS\/([.0-9]+)/;
 var chromePattern = /(?:Chrome|CrMo|CriOS)\/([.0-9]+)/;

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -34,7 +34,7 @@ var CATEGORY_LIST = exports.CATEGORY_LIST = [
 var ATTRIBUTE_LIST = exports.ATTRIBUTE_LIST = [ATTRIBUTE_NAME, ATTRIBUTE_CATEGORY, ATTRIBUTE_OS, ATTRIBUTE_VENDOR, ATTRIBUTE_VERSION, ATTRIBUTE_OS_VERSION];
 
 var DATASET = {};
-// GENERATED from dataset.yaml at Sat Aug 19 23:46:35 JST 2017 by tell_k
+// GENERATED from dataset.yaml at Sun Jul 22 01:16:13 JST 2018 by tell_k
 var obj;
 obj = {label:'MSIE', name:'Internet Explorer', type:'browser'};
 obj['vendor'] = 'Microsoft';
@@ -62,6 +62,9 @@ obj['vendor'] = 'Fenrir Inc.';
 DATASET[obj.label] = obj;
 obj = {label:'Webview', name:'Webview', type:'browser'};
 obj['vendor'] = 'OS vendor';
+DATASET[obj.label] = obj;
+obj = {label:'YaBrowser', name:'Yandex Browser', type:'browser'};
+obj['vendor'] = 'Yandex';
 DATASET[obj.label] = obj;
 obj = {label:'Win', name:'Windows UNKNOWN Ver', type:'os'};
 obj['category'] = 'pc';

--- a/lib/woothee.js
+++ b/lib/woothee.js
@@ -71,6 +71,9 @@ function tryBrowser(userAgent, result) {
   if (browser.challengeVivaldi(userAgent, result))
     return true;
 
+  if (browser.challengeYandexBrowser(userAgent, result))
+    return true;
+
   if (browser.challengeSafariChrome(userAgent, result))
     return true;
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "User-Agent string parser (js implementation)",
   "main": "./release/woothee",
   "devDependencies": {
-    "mocha": ">= 1.7.0",
+    "mocha": "~3.5.3",
     "chai": ">= 1.3.0",
     "js-yaml": ">= 1.0.3",
     "should": "~1.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woothee",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "User-Agent string parser (js implementation)",
   "main": "./release/woothee",
   "devDependencies": {

--- a/scripts/dataset_yaml2js.js
+++ b/scripts/dataset_yaml2js.js
@@ -47,7 +47,9 @@ var dumpToFile = function() {
     defs.push("DATASET[obj.label] = obj;");
   });
 
-  fs.writeFile(js_file, header_data + defs.join("\n") + footer_data);
+  fs.writeFile(js_file, header_data + defs.join("\n") + footer_data, function(err){ 
+     if (err) throw err;
+  });
 };
 
 var checkcallback = function(){

--- a/scripts/jsbuilder.js
+++ b/scripts/jsbuilder.js
@@ -63,7 +63,9 @@ var dumpToFile = function() {
     defs.push(util.format(template, modname, modname, modname, code.join("\n") + "\n"));
   });
 
-  fs.writeFile(target_path, header_data + defs.join("\n") + footer_data);
+  fs.writeFile(target_path, header_data + defs.join("\n") + footer_data, function(err) { 
+     if (err) throw err;
+  });
 };
 
 var checkcallback = function(){


### PR DESCRIPTION
I've catched up with woothee v1.8.0.

- Add YandexBrowser
- Clearly specify a callback function for fs.writeFile.
  - https://github.com/woothee/woothee-js/commit/e6f312a11c890d17189ff1f18b0a549c656b0ad9
  - https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback

```
v10.0.0 | The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime.
``` 

- Fixed mocha version.
  - https://github.com/woothee/woothee-js/commit/2fd0892c29a7fc1e39e2a6f3d5f002c1d860a8c3
  - This is because mocha no longer supports old node versions.
  - https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#compatibility.
  - I think you need to decide whether to fix mocha's version or stop supporting old node versions.

Please feel free to merge it. Thx.